### PR TITLE
Card now keeps its context around so that we can reopen it after doing

### DIFF
--- a/notecard/notecard.go
+++ b/notecard/notecard.go
@@ -18,7 +18,7 @@ import (
 // Module communication interfaces
 const (
 	NotecardInterfaceSerial = "serial"
-	NotecardInterfaceI2C	= "i2c"
+	NotecardInterfaceI2C    = "i2c"
 )
 
 // CardI2CMax controls chunk size that's socially appropriate on the I2C bus.
@@ -39,22 +39,22 @@ const CardRequestSegmentDelayMs = 250
 type Context struct {
 
 	// True to emit trace output
-	Debug			bool
+	Debug bool
 
 	// Class functions
-	PortEnumFn	   func() (ports []string, err error)
+	PortEnumFn     func() (ports []string, err error)
 	PortDefaultsFn func() (port string, portConfig int)
-	CloseFn		   func(context *Context)
-	ReopenFn	   func(context *Context) (err error)
-	ResetFn		   func(context *Context) (err error)
+	CloseFn        func(context *Context)
+	ReopenFn       func(context *Context) (err error)
+	ResetFn        func(context *Context) (err error)
 	TransactionFn  func(context *Context, reqJSON []byte) (rspJSON []byte, err error)
 
 	// Serial instance state
-	isSerial	   bool
+	isSerial       bool
 	openSerialPort *serial.Port
-	serialConfig 	serial.Config
-	i2cName		string
-	i2cAddress	int
+	serialConfig   serial.Config
+	i2cName        string
+	i2cAddress     int
 }
 
 // Report a critical card error
@@ -86,9 +86,8 @@ func (context *Context) PortDefaults() (port string, portConfig int) {
 func (context *Context) Identify() (protocol string, port string, portConfig int) {
 	if context.isSerial {
 		return "serial", context.serialConfig.Name, context.serialConfig.Baud
-	} else {
-		return "I2C", context.i2cName, context.i2cAddress
 	}
+	return "I2C", context.i2cName, context.i2cAddress
 }
 
 // Open the card to establish communications
@@ -190,9 +189,6 @@ func OpenSerial(port string, portConfig int) (context Context, err error) {
 		return
 	}
 
-	// Reset serial to a known good state
-	err = cardResetSerial(&context)
-
 	// All set
 	return
 
@@ -289,8 +285,6 @@ func cardCloseI2C(context *Context) {
 	i2cClose()
 }
 
-
-
 // Reopen the port
 func (context *Context) Reopen() (err error) {
 	return context.ReopenFn(context)
@@ -358,10 +352,10 @@ func (context *Context) TraceOutput(quiescentSecs int, maximumSecs int) (err err
 	for {
 
 		now := time.Now().Unix()
-		if quiescentSecs > 0 && now >= timeOutput + int64(quiescentSecs) {
+		if quiescentSecs > 0 && now >= timeOutput+int64(quiescentSecs) {
 			return nil
 		}
-		if maximumSecs > 0 && now >= timeStarted + int64(maximumSecs) {
+		if maximumSecs > 0 && now >= timeStarted+int64(maximumSecs) {
 			return nil
 		}
 
@@ -463,7 +457,7 @@ func inputHandler(context *Context) {
 
 			for _, r := range message[1:] {
 				switch {
-					// 'a' - 'z'
+				// 'a' - 'z'
 				case 97 <= r && r <= 122:
 					ba := make([]byte, 1)
 					ba[0] = byte(r - 96)

--- a/noteutil/config.go
+++ b/noteutil/config.go
@@ -41,7 +41,7 @@ var flagConfigHTTPS bool
 
 // Config are the master config settings
 var Config ConfigSettings
-var ConfigFlags ConfigSettings
+var configFlags ConfigSettings
 
 // ConfigRead reads the current info from config file
 func ConfigRead() error {
@@ -167,58 +167,58 @@ func ConfigFlagsProcess() (err error) {
 
 	// Set the flags as desired
 	if flagConfigHTTP {
-		ConfigFlags.Secure = false
+		configFlags.Secure = false
 		Config.Secure = false
 	}
 	if flagConfigHTTPS {
-		ConfigFlags.Secure = true
+		configFlags.Secure = true
 		Config.Secure = true
 	}
-	if ConfigFlags.Hub == "-" {
+	if configFlags.Hub == "-" {
 		Config.Hub = notehub.DefaultAPIService
-	} else if ConfigFlags.Hub != "" {
-		Config.Hub = ConfigFlags.Hub
+	} else if configFlags.Hub != "" {
+		Config.Hub = configFlags.Hub
 	}
-	if ConfigFlags.Root == "-" {
+	if configFlags.Root == "-" {
 		Config.Root = ""
-	} else if ConfigFlags.Root != "" {
-		Config.Root = ConfigFlags.Root
+	} else if configFlags.Root != "" {
+		Config.Root = configFlags.Root
 	}
-	if ConfigFlags.Key == "-" {
+	if configFlags.Key == "-" {
 		Config.Key = ""
-	} else if ConfigFlags.Key != "" {
-		Config.Key = ConfigFlags.Key
+	} else if configFlags.Key != "" {
+		Config.Key = configFlags.Key
 	}
-	if ConfigFlags.Cert == "-" {
+	if configFlags.Cert == "-" {
 		Config.Cert = ""
-	} else if ConfigFlags.Cert != "" {
-		Config.Cert = ConfigFlags.Cert
+	} else if configFlags.Cert != "" {
+		Config.Cert = configFlags.Cert
 	}
-	if ConfigFlags.App == "-" {
+	if configFlags.App == "-" {
 		Config.App = ""
-	} else if ConfigFlags.App != "" {
-		Config.App = ConfigFlags.App
+	} else if configFlags.App != "" {
+		Config.App = configFlags.App
 	}
-	if ConfigFlags.Device == "-" {
+	if configFlags.Device == "-" {
 		Config.Device = ""
-	} else if ConfigFlags.Device != "" {
-		Config.Device = ConfigFlags.Device
+	} else if configFlags.Device != "" {
+		Config.Device = configFlags.Device
 	}
-	if ConfigFlags.Product == "-" {
+	if configFlags.Product == "-" {
 		Config.Product = ""
-	} else if ConfigFlags.Product != "" {
-		Config.Product = ConfigFlags.Product
+	} else if configFlags.Product != "" {
+		Config.Product = configFlags.Product
 	}
-	if ConfigFlags.Interface == "-" {
+	if configFlags.Interface == "-" {
 		configResetInterface()
-	} else if ConfigFlags.Interface != "" {
-		Config.Interface = ConfigFlags.Interface
+	} else if configFlags.Interface != "" {
+		Config.Interface = configFlags.Interface
 	}
-	if ConfigFlags.Port != "" {
-		Config.Port = ConfigFlags.Port
+	if configFlags.Port != "" {
+		Config.Port = configFlags.Port
 	}
-	if ConfigFlags.PortConfig != -1 {
-		Config.PortConfig = ConfigFlags.PortConfig
+	if configFlags.PortConfig != -1 {
+		Config.PortConfig = configFlags.PortConfig
 	}
 
 	// Save if requested
@@ -255,18 +255,18 @@ func ConfigFlagsRegister() {
 	flag.BoolVar(&flagConfigReset, "config-reset", false, "reset the note tool config to its defaults")
 
 	// Process the commands
-	flag.StringVar(&ConfigFlags.Interface, "interface", "", "select 'serial' or 'i2c' interface")
-	flag.StringVar(&ConfigFlags.Port, "port", "", "select serial or i2c port")
-	flag.IntVar(&ConfigFlags.PortConfig, "portconfig", -1, "set serial device speed or i2c address")
+	flag.StringVar(&configFlags.Interface, "interface", "", "select 'serial' or 'i2c' interface")
+	flag.StringVar(&configFlags.Port, "port", "", "select serial or i2c port")
+	flag.IntVar(&configFlags.PortConfig, "portconfig", -1, "set serial device speed or i2c address")
 	flag.BoolVar(&flagConfigHTTP, "http", false, "use http instead of https")
 	flag.BoolVar(&flagConfigHTTPS, "https", false, "use https instead of http")
-	flag.StringVar(&ConfigFlags.Hub, "hub", "", "set notehub command service URL")
-	flag.StringVar(&ConfigFlags.Device, "device", "", "set DeviceUID")
-	flag.StringVar(&ConfigFlags.Product, "product", "", "set ProductUID")
-	flag.StringVar(&ConfigFlags.App, "app", "", "set AppUID (the Project UID)")
-	flag.StringVar(&ConfigFlags.Root, "root", "", "set path to service's root CA certificate file")
-	flag.StringVar(&ConfigFlags.Key, "key", "", "set path to local private key file")
-	flag.StringVar(&ConfigFlags.Cert, "cert", "", "set path to local cert file")
+	flag.StringVar(&configFlags.Hub, "hub", "", "set notehub command service URL")
+	flag.StringVar(&configFlags.Device, "device", "", "set DeviceUID")
+	flag.StringVar(&configFlags.Product, "product", "", "set ProductUID")
+	flag.StringVar(&configFlags.App, "app", "", "set AppUID (the Project UID)")
+	flag.StringVar(&configFlags.Root, "root", "", "set path to service's root CA certificate file")
+	flag.StringVar(&configFlags.Key, "key", "", "set path to local private key file")
+	flag.StringVar(&configFlags.Cert, "cert", "", "set path to local cert file")
 
 	// Write the config if asked to do so
 	flag.BoolVar(&flagConfigSave, "config-save", false, "save changes to note tool config")


### PR DESCRIPTION
operations that cause it to reboot. That is, we can now do:
    Open(params)
    Transaction({card.restore}) --> causes reboot which causes serial port to go away
    Close()
    Reopen()

This is used by an open PR on hub, so we need to tag it on master once this PR is complete.