### PR TITLE
TraceCapture() bugfix

### DIFF
--- a/notecard/trace.go
+++ b/notecard/trace.go
@@ -71,10 +71,8 @@ func (context *Context) TraceCapture(toSend string, toEnd string, quiescentSecs 
 			}
 			break
 		}
-		fragment := string(buf[:length])
-		captured += fragment
-		if (toEnd != "" && strings.Contains(fragment, toEnd)) {
-			captured += "\n"
+		captured += string(buf[:length])
+		if (toEnd != "" && strings.Contains(captured, toEnd)) {
 			break
 		}
 		timeOutput = time.Now().Unix()


### PR DESCRIPTION
If toEnd was read across a fragment boundary, we would have missed it.