### PR TITLE
CircleCI setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,11 +18,10 @@ jobs:
           command: find * -name 'main.go' -execdir go build -x -o "$(pwd)/artifacts/" \;
       - store_artifacts:
           path: artifacts
+
   publish-github-release:
     docker:
       - image: cibuilds/github:0.10
-    requires:
-      - build
     steps:
       - attach_workspace:
           at: ./artifacts
@@ -31,3 +30,11 @@ jobs:
           command: |
             VERSION="$(git describe --dirty)"
             ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${VERSION} ./artifacts/
+workflows:
+  version: 2
+  build-and-publish:
+    jobs:
+      - build
+      - publish-github-release:
+          requires:
+            - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,7 @@ jobs:
     docker:
       - image: cibuilds/github:0.10
     steps:
+      - checkout
       - attach_workspace:
           at: ./artifacts
       - run:
@@ -30,6 +31,7 @@ jobs:
           command: |
             VERSION="$(git describe --dirty)"
             ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${VERSION} ./artifacts/
+
 workflows:
   version: 2
   build-and-publish:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,9 +51,9 @@ workflows:
             # https://app.circleci.com/settings/project/github/blues/note-go/advanced
             tags: &PUBLISH_TAG_FILTER_REGEX
               # Unlike branch-triggered builds, we do filter down to certain
-              # tags. Match 1.2.3 etc. i.e. only build for tags that look like
+              # tags. Match v1.2.3 etc. i.e. only build for tags that look like
               # they're tagging a release.
-              only: /^\d+\.\d+\.\d+$/
+              only: /^v\d+\.\d+\.\d+$/
       - publish-github-release:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,6 @@ jobs:
           command: find * -name 'main.go' -execdir go build -x -o "$(pwd)/artifacts/" \;
       - store_artifacts:
           path: artifacts
-
   publish-github-release:
     docker:
       - image: cibuilds/github:0.10

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,6 @@ jobs:
     working_directory: /go/src/github.com/blues/note-go
     steps:
       - checkout
-      - run: export GOOS=linux   GOARCH=386   ; ./build.sh && ./package.sh
       - run: export GOOS=linux   GOARCH=amd64 ; ./build.sh && ./package.sh
       - run: export GOOS=linux   GOARCH=arm   ; ./build.sh && ./package.sh
       - run: export GOOS=windows GOARCH=386   ; ./build.sh && ./package.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
           name: "Publish Release on GitHub"
           command: |
             VERSION="$(git describe --dirty)"
-            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} 
+            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} \
                 -c ${CIRCLE_SHA1} -delete ${VERSION} ./build/packages/
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
       # We need to do a checkout so the CIRCLE_PROJECT_REPONAME and CIRCLE_SHA1 vars are populated for the command below.
       - checkout
       - attach_workspace:
-          at: ./artifacts
+          at: .
       - run: ls -l ./artifacts/
       - run:
           name: "Publish Release on GitHub"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,10 +45,10 @@ workflows:
       - publish-github-release:
           requires:
             - build
-          # filters:
-          #   branches:
-          #     ignore: /.*/
-          #   tags:
-          #     # match 1.2.3 etc. i.e. only tags that look like they're tagging a release.
-          #     only: /^\d+\.\d+\.\d+$/
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              # match 1.2.3 etc. i.e. only tags that look like they're tagging a release.
+              only: /^\d+\.\d+\.\d+$/
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,9 +7,10 @@ jobs:
     docker:
       - image: circleci/golang:1.13.7
     working_directory: /go/src/github.com/blues/note-go
+    persist_to_workspace: ./artifacts/
     steps:
       - checkout
-      - run: mkdir artifacts
+      - run: mkdir -p ./artifacts/
       - run:
           name: Build all executable binaries. (note, notehub, notecard, ...)
           environment:
@@ -18,3 +19,16 @@ jobs:
       - store_artifacts:
           path: artifacts
 
+  publish-github-release:
+    docker:
+      - image: cibuilds/github:0.10
+    requires:
+      - build
+    steps:
+      - attach_workspace:
+          at: ./artifacts
+      - run:
+          name: "Publish Release on GitHub"
+          command: |
+            VERSION="$(git describe --dirty)"
+            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${VERSION} ./artifacts/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,10 +44,10 @@ workflows:
       - publish-github-release:
           requires:
             - build
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              # match 1.2.3 etc. i.e. only tags that look like they're tagging a release.
-              only: /^\d+\.\d+\.\d+$/
+          # filters:
+          #   branches:
+          #     ignore: /.*/
+          #   tags:
+          #     # match 1.2.3 etc. i.e. only tags that look like they're tagging a release.
+          #     only: /^\d+\.\d+\.\d+$/
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,12 +17,15 @@ jobs:
           command: find * -name 'main.go' -execdir go build -x -o "$(pwd)/artifacts/" \;
       - store_artifacts:
           path: ./artifacts/
-      - persist_to_workspace: ./artifacts/
+      - persist_to_workspace:
+          root: .
+          paths: ./artifacts/
 
   publish-github-release:
     docker:
       - image: cibuilds/github:0.10
     steps:
+      # We need to do a checkout so the CIRCLE_PROJECT_REPONAME and CIRCLE_SHA1 vars are populated for the command below.
       - checkout
       - attach_workspace:
           at: ./artifacts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,16 +10,24 @@ jobs:
     steps:
       - checkout
       - run: mkdir -p ./artifacts/
+      - run: GOOS=linux   GOARCH=386   ./build.sh
+      - run: GOOS=linux   GOARCH=amd64 ./build.sh
+      - run: GOOS=linux   GOARCH=arm   ./build.sh
+      - run: GOOS=windows GOARCH=386   ./build.sh
+      - run: GOOS=windows GOARCH=amd64 ./build.sh
+      - run: find products -type f -exec file '{}' +
       - run:
-          name: Build all executable binaries. (note, notehub, notecard, ...)
+          name: Darwin Build executables. (note, notehub, notecard, ...)
           environment:
             GO111MODULE: "on"
-          command: find * -name 'main.go' -execdir go build -x -o "$(pwd)/artifacts/" \;
+            GOOS: "darwin"
+          command: find * -name 'main.go' -execdir go build -x -o "$(pwd)/executables/" \;
       - store_artifacts:
-          path: ./artifacts/
+          path: ./products/
       - persist_to_workspace:
           root: .
-          paths: ./artifacts/
+          paths:
+            - products
 
   publish-github-release:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,3 +43,10 @@ workflows:
       - publish-github-release:
           requires:
             - build
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              # match 1.2.3 etc. i.e. only tags that look like they're tagging a release.
+              only: /^\d+\.\d+\.\d+$/
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
       - run: export GOOS=linux   GOARCH=arm   ; ./build.sh && ./package.sh
       - run: export GOOS=windows GOARCH=386   ; ./build.sh && ./package.sh
       - run: export GOOS=windows GOARCH=amd64 ; ./build.sh && ./package.sh
-      - run: find ./build/ -type f -print0 | xargs --null file
+      - run: find ./build/ -type f
       - store_artifacts:
           path: ./build/packages/
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,19 +36,28 @@ jobs:
             VERSION="$(git describe --dirty)"
             ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} \
                 -c ${CIRCLE_SHA1} -delete ${VERSION} ./build/packages/
+          # The GITHUB_TOKEN is generated here: https://github.com/settings/tokens for the notebot-ci user and securely
+          # set here: https://app.circleci.com/settings/project/github/blues/note-go/environment-variables
 
 workflows:
   version: 2
   build-and-publish:
     jobs:
-      - build
+      - build:
+          filters:
+            # Because we don't filter out certain branches this code implicitly
+            # says `build` will run for all builds triggered by a branch push
+            # or PR. But in the circle-ci ui we chose to only build for PRs here:
+            # https://app.circleci.com/settings/project/github/blues/note-go/advanced
+            tags: &PUBLISH_TAG_FILTER_REGEX
+              # Unlike branch-triggered builds, we do filter down to certain
+              # tags. Match 1.2.3 etc. i.e. only build for tags that look like
+              # they're tagging a release.
+              only: /^\d+\.\d+\.\d+$/
       - publish-github-release:
           requires:
             - build
           filters:
             branches:
               ignore: /.*/
-            tags:
-              # match 1.2.3 etc. i.e. only tags that look like they're tagging a release.
-              only: /^\d+\.\d+\.\d+$/
-
+            tags: *PUBLISH_TAG_FILTER_REGEX

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,7 @@ jobs:
       - checkout
       - attach_workspace:
           at: ./artifacts
+      - run: ls -l ./artifacts/
       - run:
           name: "Publish Release on GitHub"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,6 @@ jobs:
     docker:
       - image: circleci/golang:1.13.7
     working_directory: /go/src/github.com/blues/note-go
-    persist_to_workspace: ./artifacts/
     steps:
       - checkout
       - run: mkdir -p ./artifacts/
@@ -17,7 +16,8 @@ jobs:
             GO111MODULE: "on"
           command: find * -name 'main.go' -execdir go build -x -o "$(pwd)/artifacts/" \;
       - store_artifacts:
-          path: artifacts
+          path: ./artifacts/
+      - persist_to_workspace: ./artifacts/
 
   publish-github-release:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,25 +9,18 @@ jobs:
     working_directory: /go/src/github.com/blues/note-go
     steps:
       - checkout
-      - run: mkdir -p ./artifacts/
-      - run: GOOS=linux   GOARCH=386   ./build.sh
-      - run: GOOS=linux   GOARCH=amd64 ./build.sh
-      - run: GOOS=linux   GOARCH=arm   ./build.sh
-      - run: GOOS=windows GOARCH=386   ./build.sh
-      - run: GOOS=windows GOARCH=amd64 ./build.sh
-      - run: find products -type f -exec file '{}' +
-      - run:
-          name: Darwin Build executables. (note, notehub, notecard, ...)
-          environment:
-            GO111MODULE: "on"
-            GOOS: "darwin"
-          command: find * -name 'main.go' -execdir go build -x -o "$(pwd)/executables/" \;
+      - run: export GOOS=linux   GOARCH=386   ; ./build.sh && ./package.sh
+      - run: export GOOS=linux   GOARCH=amd64 ; ./build.sh && ./package.sh
+      - run: export GOOS=linux   GOARCH=arm   ; ./build.sh && ./package.sh
+      - run: export GOOS=windows GOARCH=386   ; ./build.sh && ./package.sh
+      - run: export GOOS=windows GOARCH=amd64 ; ./build.sh && ./package.sh
+      - run: find ./build/ -type f -print0 | xargs --null file
       - store_artifacts:
-          path: ./products/
+          path: ./build/packages/
       - persist_to_workspace:
           root: .
           paths:
-            - products
+            - ./build/packages/
 
   publish-github-release:
     docker:
@@ -37,12 +30,13 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - run: ls -l ./artifacts/
+      - run: ls -l ./build/packages/
       - run:
           name: "Publish Release on GitHub"
           command: |
             VERSION="$(git describe --dirty)"
-            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${VERSION} ./artifacts/
+            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} 
+                -c ${CIRCLE_SHA1} -delete ${VERSION} ./build/packages/
 
 workflows:
   version: 2

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 build
 
 # Production build proucts
-products/
+./build/
 
 # Binaries for programs and plugins
 *.exe

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 **/.idea
 build
 
+# Production build proucts
+products/
+
 # Binaries for programs and plugins
 *.exe
 *.exe~

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,31 @@
+#! /usr/bin/env bash
+######### Bash Boilerplate ##########
+set -euo pipefail # strict mode
+readonly SCRIPT_NAME="$(basename "$0")"
+readonly SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd "$SCRIPT_DIR" # cd to this script's dir
+######### End Bash Boilerplate ##########
+
+# Add GOOS and GOARCH to our environment. (and other GO vars we don't need)
+eval "$(go env)"
+
+# Create /product/ dir to hold the output of this script.
+readonly BUILD_PRODUCT_DIR="$SCRIPT_DIR/products/$GOOS/$GOARCH/"
+mkdir -p "$BUILD_PRODUCT_DIR"
+
+# build_dirs is an array of all the folders which contain a main.go
+readarray -t build_dirs < <(find . -name 'main.go' -print0 | xargs --null dirname)
+for dir in "${build_dirs[@]}"; do
+  (
+    cd "$dir"
+    go build -o "$BUILD_PRODUCT_DIR"
+  ) 
+done
+
+# compress the build products into an archive
+cd "$BUILD_PRODUCT_DIR"
+if [ "$GOOS" = "windows" ]; then
+  zip note-go.$GOOS.$GOARCH.zip ./*
+else
+  tar -czvf note-go.$GOOS.$GOARCH.tar.gz ./*
+fi;

--- a/build.sh
+++ b/build.sh
@@ -1,31 +1,38 @@
 #! /usr/bin/env bash
+#
+# Copyright 2020 Blues Inc.  All rights reserved.
+# Use of this source code is governed by licenses granted by the
+# copyright holder including that found in the LICENSE file.
+#
 ######### Bash Boilerplate ##########
 set -euo pipefail # strict mode
-readonly SCRIPT_NAME="$(basename "$0")"
 readonly SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd "$SCRIPT_DIR" # cd to this script's dir
 ######### End Bash Boilerplate ##########
 
+#
+# note-go build.sh
+#
+# This script builds all the note-go executables (note, notecard, notehub) by
+# looking for any folder containing a main.go and running `go build`.
+#
+# Parameters: Set $GOOS and $GOARCH to cross compile for different platforms.
+#
+# Output: Executables are saved in "./build/$GOOS/$GOARCH/"
+#
+
 # Add GOOS and GOARCH to our environment. (and other GO vars we don't need)
 eval "$(go env)"
 
-# Create /product/ dir to hold the output of this script.
-readonly BUILD_PRODUCT_DIR="$SCRIPT_DIR/products/$GOOS/$GOARCH/"
-mkdir -p "$BUILD_PRODUCT_DIR"
+readonly BUILD_EXE_DIR="$SCRIPT_DIR/build/$GOOS/$GOARCH/"
+mkdir -p "$BUILD_EXE_DIR"
 
-# build_dirs is an array of all the folders which contain a main.go
+# Build each executable binary
 readarray -t build_dirs < <(find . -name 'main.go' -print0 | xargs --null dirname)
+# build_dirs is an array of all the folders which contain a main.go
 for dir in "${build_dirs[@]}"; do
   (
     cd "$dir"
-    go build -o "$BUILD_PRODUCT_DIR"
+    go build -o "$BUILD_EXE_DIR"
   ) 
 done
-
-# compress the build products into an archive
-cd "$BUILD_PRODUCT_DIR"
-if [ "$GOOS" = "windows" ]; then
-  zip note-go.$GOOS.$GOARCH.zip ./*
-else
-  tar -czvf note-go.$GOOS.$GOARCH.tar.gz ./*
-fi;

--- a/package.sh
+++ b/package.sh
@@ -1,0 +1,40 @@
+#! /usr/bin/env bash
+#
+# Copyright 2020 Blues Inc.  All rights reserved.
+# Use of this source code is governed by licenses granted by the
+# copyright holder including that found in the LICENSE file.
+#
+######### Bash Boilerplate ##########
+set -euo pipefail # strict mode
+readonly SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd "$SCRIPT_DIR" # cd to this script's dir
+######### End Bash Boilerplate ##########
+
+#
+# note-go package.sh
+#
+# This script packages all the note-go executables (note, notecard, notehub)
+# into an archive named note-go.$GOOS.$GOARCH.tar.gz or zip in the case of
+# $GOOS=windows.
+#
+# Parameters: This script uses $GOOS and $GOARCH determine where to look for the
+#             executables.
+#
+# Output: Archives are saved in "./build/packages/"
+#
+
+# Add GOOS and GOARCH to our environment. (and other GO vars we don't need)
+eval "$(go env)"
+
+readonly BUILD_EXE_DIR="$SCRIPT_DIR/build/$GOOS/$GOARCH/"
+mkdir -p "$BUILD_EXE_DIR"
+readonly BUILD_PACKAGE_DIR="$SCRIPT_DIR/build/packages/"
+mkdir -p "$BUILD_PACKAGE_DIR"
+
+# compress the build products into an archive
+cd "$BUILD_EXE_DIR"
+if [ "$GOOS" = "windows" ]; then
+  zip "$BUILD_PACKAGE_DIR/note-go.$GOOS.$GOARCH.zip" ./*
+else
+  tar -czvf "$BUILD_PACKAGE_DIR/note-go.$GOOS.$GOARCH.tar.gz" ./*
+fi;


### PR DESCRIPTION
After this PR we should have automated builds for every push of code to a branch associated with a pull request.

We will also have automatic publishing of executable binaries to the GitHub release page triggered by pushing a new tag of the form `v1.2.3`.
`git tag --annotate --message='This is the best version yet' v4.5.7 && git push --tags`

todo: Add MacOS when circle-ci approves our account for OSS MacOS Builds.