### PR TITLE
chore: circleci macos build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@
 # Check https://circleci.com/docs/2.0/language-go/ for more details
 version: 2
 jobs:
-  build:
+  build-unix-and-windows:
     docker:
       - image: circleci/golang:1.13.7
     working_directory: /go/src/github.com/blues/note-go
@@ -20,12 +20,36 @@ jobs:
           root: .
           paths:
             - ./build/packages/
-
+  build-macos:
+    macos:
+      xcode: 11.3.0
+    steps:
+      - checkout
+      - run: pwd
+      - run: echo $PATH
+      - run:
+          name: install go
+          command: |
+            curl https://dl.google.com/go/go1.13.7.darwin-amd64.tar.gz | 
+              tar -C "$HOME" -xz # install go to $HOME/go/
+      - run:
+          name: build and package
+          command: |
+            export PATH="$PATH:$HOME/go/bin"
+            ./build.sh
+            ./package.sh
+      - store_artifacts:
+          path: ./build/packages/
+      - persist_to_workspace:
+          root: .
+          paths:
+            - ./build/packages/
   publish-github-release:
     docker:
       - image: cibuilds/github:0.10
     steps:
-      # We need to do a checkout so the CIRCLE_PROJECT_REPONAME and CIRCLE_SHA1 vars are populated for the command below.
+      # We need to do a checkout so the CIRCLE_PROJECT_REPONAME and CIRCLE_SHA1 vars are populated
+      # for the command below.
       - checkout
       - attach_workspace:
           at: .
@@ -36,27 +60,31 @@ jobs:
             VERSION="$(git describe --dirty)"
             ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} \
                 -c ${CIRCLE_SHA1} -delete ${VERSION} ./build/packages/
-          # The GITHUB_TOKEN is generated here: https://github.com/settings/tokens for the notebot-ci user and securely
-          # set here: https://app.circleci.com/settings/project/github/blues/note-go/environment-variables
+          # The GITHUB_TOKEN is generated here: https://github.com/settings/tokens for the
+          # notebot-ci user and securely set here:
+          # https://app.circleci.com/settings/project/github/blues/note-go/environment-variables
 
 workflows:
   version: 2
   build-and-publish:
     jobs:
-      - build:
+      - build-macos:
           filters:
-            # Because we don't filter out certain branches this code implicitly
-            # says `build` will run for all builds triggered by a branch push
-            # or PR. But in the circle-ci ui we chose to only build for PRs here:
+            # Because we don't filter out certain branches this code implicitly says `build-macos`
+            # will run for all builds triggered by a branch push or PR. But in the circle-ci ui we
+            # chose to only build for PRs here:
             # https://app.circleci.com/settings/project/github/blues/note-go/advanced
             tags: &PUBLISH_TAG_FILTER_REGEX
-              # Unlike branch-triggered builds, we do filter down to certain
-              # tags. Match v1.2.3 etc. i.e. only build for tags that look like
-              # they're tagging a release.
+              # Unlike branch-triggered builds, we do filter down to certain tags. Match v1.2.3 etc.
+              # i.e. the only tags which can trigger must look like they're tagging a release.
               only: /^v\d+\.\d+\.\d+$/
+      - build-unix-and-windows:
+          filters:
+            tags: *PUBLISH_TAG_FILTER_REGEX
       - publish-github-release:
           requires:
-            - build
+            - build-macos
+            - build-unix-and-windows
           filters:
             branches:
               ignore: /.*/

--- a/build.sh
+++ b/build.sh
@@ -28,8 +28,8 @@ readonly BUILD_EXE_DIR="$SCRIPT_DIR/build/$GOOS/$GOARCH/"
 mkdir -p "$BUILD_EXE_DIR"
 
 # Build each executable binary
-readarray -t build_dirs < <(find . -name 'main.go' -print0 | xargs --null dirname)
 # build_dirs is an array of all the folders which contain a main.go
+IFS=$'\r\n' GLOBIGNORE='*' command eval  'build_dirs=($(find . -name main.go -print0 | xargs -0n1 dirname))'
 for dir in "${build_dirs[@]}"; do
   (
     cd "$dir"


### PR DESCRIPTION
This PR adds MacOS builds of `notecard`, `note`, and `notehub`. 
Example [artifacts](https://app.circleci.com/pipelines/github/blues/note-go/30/workflows/2dfae70d-e672-4dfd-8a58-ddb46ac53dc3/jobs/51/artifacts).