### PR TITLE
implement support needed for next gen of notefarms

### DIFF
--- a/note/access.go
+++ b/note/access.go
@@ -44,6 +44,9 @@ const ACResourceNotecardFirmwares = "notecard:*"
 // ACResourceUserFirmwares is the resource for all user firmware
 const ACResourceUserFirmwares = "firmware:*"
 
+// ACResourceNotefarms is the resource for all notefarm descriptors
+const ACResourceNotefarms = "notefarm:*"
+
 // ACResourceSep is the separator for building compound resource names
 const ACResourceSep = ":"
 

--- a/notecard/notecard.go
+++ b/notecard/notecard.go
@@ -540,13 +540,13 @@ func (context *Context) TransactionJSON(reqJSON []byte) (rspJSON []byte, err err
 		reqJSON = []byte(string(reqJSON) + "\n")
 	}
 
+	// Only one caller at a time
+	transLock.Lock()
+
 	// Do a reset if one was pending
 	if context.resetRequired {
 		context.Reset()
 	}
-
-	// Only one caller at a time
-	transLock.Lock()
 
 	// Reopen if error
 	if context.reopenRequired {

--- a/notecard/test.go
+++ b/notecard/test.go
@@ -6,6 +6,7 @@ package notecard
 
 // CardTest is a structure that is returned by the notecard after completing its self-test
 type CardTest struct {
+	DeviceUID  string `json:"device,omitempty"`
 	Error      string `json:"err,omitempty"`
 	Status     string `json:"status,omitempty"`
 	Tests      string `json:"tests,omitempty"`

--- a/notehub/request.go
+++ b/notehub/request.go
@@ -23,17 +23,32 @@ const HubQuery = "hub.app.data.query"
 // HubAppUpload (golint)
 const HubAppUpload = "hub.app.upload.add"
 
+// HubUpload (golint)
+const HubUpload = "hub.upload.add"
+
 // HubAppUploads (golint)
 const HubAppUploads = "hub.app.upload.query"
+
+// HubUploads (golint)
+const HubUploads = "hub.upload.query"
 
 // HubAppUploadSet (golint)
 const HubAppUploadSet = "hub.app.upload.set"
 
+// HubUploadSet (golint)
+const HubUploadSet = "hub.upload.set"
+
 // HubAppUploadDelete (golint)
 const HubAppUploadDelete = "hub.app.upload.delete"
 
+// HubUploadDelete (golint)
+const HubUploadDelete = "hub.upload.delete"
+
 // HubAppUploadRead (golint)
 const HubAppUploadRead = "hub.app.upload.get"
+
+// HubUploadRead (golint)
+const HubUploadRead = "hub.upload.get"
 
 // HubEnvSet (golint)
 const HubEnvSet = "hub.env.set"
@@ -76,6 +91,9 @@ const HubFileTypeUserFirmware = "firmware"
 
 // HubFileTypeCardFirmware (golint)
 const HubFileTypeCardFirmware = "notecard"
+
+// HubFileTypeNotefarm (golint)
+const HubFileTypeNotefarm = "notefarm"
 
 // HubRequestFileFirmware is firmware-specific metadata
 type HubRequestFileFirmware struct {


### PR DESCRIPTION
and also implement notelib fix that Sean needs to test

* inconsistency between notecard/notehub note.changes (with tracker)
handling of deleted notes

* implement DbUnibase placeholder for when Devin implements it, because
I am about to create another use for it besides notecard firmware and
the leaderboard

* upload/fetch mechanism implemented to replace notefarm.live for
hosting farm device descriptor docs

* remove notehub exe

* amend gitignore to ignore notehub exe

* implement device directory within unibase (devin & stefan, see
hublib/ddir.go)