### PR TITLE
fix: tolerate /userinfo responses without an email claim

### DIFF
--- a/notehub/auth.go
+++ b/notehub/auth.go
@@ -276,16 +276,26 @@ func InitiateBrowserBasedLogin(notehubApiHost string) (*AccessToken, error) {
 	router.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		action := classifyCallback(r, state)
 
-		// A request that isn't the OAuth redirect (favicon, prefetch, a bare
-		// visit to the root) must not be mistaken for a failed sign-in nor tear
-		// the flow down before the real redirect arrives.
-		if action == callbackIgnore {
+		switch action {
+		case callbackIgnore:
+			// Not the OAuth redirect (favicon, prefetch, a bare visit to the
+			// root); ignore it without affecting the flow.
 			w.WriteHeader(http.StatusNoContent)
+			return
+		case callbackStateMismatch:
+			// A request whose state doesn't match this attempt is unrelated to
+			// it -- a stray local request, another browser tab, or (since the
+			// callback ports are a predictable, hard-coded list) a webpage
+			// probing localhost. Reject it benignly: it must neither abort the
+			// in-progress login nor consume the single-callback slot below, so
+			// it cannot be used to deny service to a legitimate sign-in.
+			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
 
-		// Handle exactly one callback; answer any duplicate benignly so a
-		// second request cannot race the shared result or signal shutdown twice.
+		// Only a redirect whose state matches reaches here. Handle exactly one;
+		// answer any duplicate benignly so a second request cannot race the
+		// shared result or signal shutdown twice.
 		handled := false
 		once.Do(func() { handled = true })
 		if !handled {
@@ -326,11 +336,6 @@ func InitiateBrowserBasedLogin(notehubApiHost string) (*AccessToken, error) {
 			case quit <- os.Interrupt:
 			default:
 			}
-		}
-
-		if action == callbackStateMismatch {
-			fail("state mismatch", "")
-			return
 		}
 
 		// The provider refused or failed the authorization (e.g. the user

--- a/notehub/auth.go
+++ b/notehub/auth.go
@@ -19,6 +19,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -79,6 +80,35 @@ func redactSensitive(body []byte) string {
 		return string(out)
 	}
 	return string(body)
+}
+
+// callbackAction classifies an inbound request to the local OAuth callback
+// server.
+type callbackAction int
+
+const (
+	// callbackIgnore: not the OAuth redirect (e.g. favicon, prefetch, a bare
+	// visit to the root). Must be answered benignly without affecting the flow.
+	callbackIgnore callbackAction = iota
+	// callbackStateMismatch: carries an authorization code but the wrong state
+	// (a CSRF attempt or a stale redirect). Must fail closed.
+	callbackStateMismatch
+	// callbackProceed: a well-formed redirect whose state matches.
+	callbackProceed
+)
+
+// classifyCallback decides how to treat a request to the callback server. A
+// request without an authorization code is not the OAuth redirect at all and
+// is ignored; one with a code is honored only if its state matches the value
+// the flow generated.
+func classifyCallback(r *http.Request, expectedState string) callbackAction {
+	if r.URL.Query().Get("code") == "" {
+		return callbackIgnore
+	}
+	if r.URL.Query().Get("state") != expectedState {
+		return callbackStateMismatch
+	}
+	return callbackProceed
 }
 
 type AccessToken struct {
@@ -198,6 +228,11 @@ func InitiateBrowserBasedLogin(notehubApiHost string) (*AccessToken, error) {
 	signal.Notify(quit, os.Interrupt)
 	defer signal.Reset(os.Interrupt)
 
+	// Ensures exactly one OAuth callback is processed; spurious or duplicate
+	// requests to the callback server are answered benignly without touching
+	// the shared result or triggering shutdown.
+	var once sync.Once
+
 	router := http.NewServeMux()
 
 	// We'll fill this after we pick a port but declare it now so the handler can close over it.
@@ -206,8 +241,28 @@ func InitiateBrowserBasedLogin(notehubApiHost string) (*AccessToken, error) {
 	// The browser will be redirected to this endpoint with an authorization code
 	// and then this endpoint will exchange that authorization code for an access token
 	router.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		action := classifyCallback(r, state)
+
+		// A request that isn't the OAuth redirect (favicon, prefetch, a bare
+		// visit to the root) must not be mistaken for a failed sign-in nor tear
+		// the flow down before the real redirect arrives.
+		if action == callbackIgnore {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+
+		// Handle exactly one callback; answer any duplicate benignly so a
+		// second request cannot race the shared result or signal shutdown twice.
+		handled := false
+		once.Do(func() { handled = true })
+		if !handled {
+			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, "authentication already completed; you may close this window")
+			return
+		}
+
 		authorizationCode := r.URL.Query().Get("code")
-		callbackState := r.URL.Query().Get("state")
 
 		// fail records an authentication failure exactly one way for every
 		// error path in this handler. The browser callback only ever receives
@@ -240,7 +295,7 @@ func InitiateBrowserBasedLogin(notehubApiHost string) (*AccessToken, error) {
 			}
 		}
 
-		if callbackState != state {
+		if action == callbackStateMismatch {
 			fail("state mismatch", "")
 			return
 		}
@@ -441,5 +496,12 @@ func InitiateBrowserBasedLogin(notehubApiHost string) (*AccessToken, error) {
 
 	// Wait for exchange to finish
 	<-done
+
+	// A shutdown with neither result set means the flow was interrupted (e.g.
+	// an OS signal) before any callback completed. Return an error rather than
+	// a nil token and nil error, which a caller would dereference.
+	if accessToken == nil && accessTokenErr == nil {
+		accessTokenErr = errors.New("authentication canceled before completion")
+	}
 	return accessToken, accessTokenErr
 }

--- a/notehub/auth.go
+++ b/notehub/auth.go
@@ -17,9 +17,39 @@ import (
 	"os/exec"
 	"os/signal"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 )
+
+const (
+	// maxResponseBytes bounds how much of an OAuth/OIDC HTTP response body we
+	// read, so a hostile or misconfigured endpoint cannot exhaust memory. It
+	// is far larger than any legitimate token or userinfo response.
+	maxResponseBytes = 1 << 20 // 1 MiB
+
+	// maxDetailBytes bounds how much of an (untrusted) value is embedded into
+	// a log line or returned error.
+	maxDetailBytes = 1024
+)
+
+// readResponseBody reads up to maxResponseBytes from an HTTP response body.
+func readResponseBody(resp *http.Response) ([]byte, error) {
+	return io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+}
+
+// safeDetail renders an untrusted value for inclusion in logs and returned
+// errors. It truncates to maxDetailBytes and quotes the result so control
+// characters (such as terminal escape sequences) are shown as printable
+// escapes rather than interpreted by a terminal.
+func safeDetail(s string) string {
+	suffix := ""
+	if len(s) > maxDetailBytes {
+		s = s[:maxDetailBytes]
+		suffix = " (truncated)"
+	}
+	return strconv.Quote(s) + suffix
+}
 
 type AccessToken struct {
 	Host        string
@@ -149,19 +179,28 @@ func InitiateBrowserBasedLogin(notehubApiHost string) (*AccessToken, error) {
 		authorizationCode := r.URL.Query().Get("code")
 		callbackState := r.URL.Query().Get("state")
 
-		errHandler := func(msg string) {
-			// text/plain so any server-controlled bytes that reach this
-			// callback (OAuth error_description, JSON unmarshal errors,
-			// etc.) cannot be rendered as HTML by the browser.
+		// fail records an authentication failure exactly one way for every
+		// error path in this handler. The browser callback only ever receives
+		// `summary` -- a constant, developer-authored string, never server-
+		// controlled data -- and always as text/plain, so the callback cannot
+		// be used to reflect injected markup or scripts. `detail` (already
+		// passed through safeDetail by the caller) carries diagnostics to the
+		// local log and the returned Go error only.
+		fail := func(summary, detail string) {
 			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 			w.WriteHeader(http.StatusInternalServerError)
-			fmt.Fprintf(w, "error: %s", msg)
+			fmt.Fprintf(w, "error: %s", summary)
+
+			msg := summary
+			if detail != "" {
+				msg = summary + ": " + detail
+			}
 			fmt.Printf("error: %s\n", msg)
 			accessTokenErr = errors.New(msg)
 		}
 
 		if callbackState != state {
-			errHandler("state mismatch")
+			fail("state mismatch", "")
 			return
 		}
 
@@ -185,42 +224,41 @@ func InitiateBrowserBasedLogin(notehubApiHost string) (*AccessToken, error) {
 			}.Encode()),
 		)
 		if err != nil {
-			errHandler("error on /oauth2/token: " + err.Error())
+			fail("could not reach /oauth2/token", safeDetail(err.Error()))
 			return
 		}
 		defer tokenResp.Body.Close()
 
-		body, err := io.ReadAll(tokenResp.Body)
+		body, err := readResponseBody(tokenResp)
 		if err != nil {
-			errHandler("could not read body from /oauth2/token: " + err.Error())
+			fail("could not read /oauth2/token response", safeDetail(err.Error()))
 			return
 		}
 
 		var tokenData map[string]interface{}
 		if err := json.Unmarshal(body, &tokenData); err != nil {
-			// Surface the HTTP status when /oauth2/token returns a non-200
-			// with a non-JSON body, so the underlying failure isn't hidden
-			// behind a generic unmarshal error.
+			// A non-200 with a non-JSON body would otherwise be hidden behind
+			// a generic unmarshal error, so surface the HTTP status too.
 			if tokenResp.StatusCode != http.StatusOK {
-				errHandler(fmt.Sprintf("/oauth2/token returned HTTP %d: %q", tokenResp.StatusCode, body))
+				fail(fmt.Sprintf("/oauth2/token returned HTTP %d", tokenResp.StatusCode), safeDetail(string(body)))
 			} else {
-				errHandler("could not unmarshal body from /oauth2/token: " + err.Error())
+				fail("could not parse /oauth2/token response", safeDetail(string(body)))
 			}
 			return
 		}
 
 		if errCode, ok := tokenData["error"].(string); ok {
+			detail := errCode
 			if errDescription, ok2 := tokenData["error_description"].(string); ok2 {
-				errHandler(fmt.Sprintf("%s: %s", errCode, errDescription))
-			} else {
-				errHandler(errCode)
+				detail = errCode + ": " + errDescription
 			}
+			fail("/oauth2/token returned an error", safeDetail(detail))
 			return
 		}
 
 		accessTokenString, ok := tokenData["access_token"].(string)
 		if !ok {
-			errHandler("unexpected error: no access token returned")
+			fail("no access token in /oauth2/token response", "")
 			return
 		}
 
@@ -241,41 +279,31 @@ func InitiateBrowserBasedLogin(notehubApiHost string) (*AccessToken, error) {
 
 		req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("https://%s/userinfo", notehubApiHost), nil)
 		if err != nil {
-			errHandler("could not create request for /userinfo: " + err.Error())
+			fail("could not create /userinfo request", safeDetail(err.Error()))
 			return
 		}
 		req.Header.Set("Authorization", "Bearer "+accessTokenString)
 		userinfoResp, err := http.DefaultClient.Do(req)
 		if err != nil {
-			errHandler("could not get userinfo: " + err.Error())
+			fail("could not reach /userinfo", safeDetail(err.Error()))
 			return
 		}
 		defer userinfoResp.Body.Close()
 
-		userinfoBody, err := io.ReadAll(userinfoResp.Body)
+		userinfoBody, err := readResponseBody(userinfoResp)
 		if err != nil {
-			errHandler("could not read body from /userinfo: " + err.Error())
+			fail("could not read /userinfo response", safeDetail(err.Error()))
 			return
 		}
 
 		if userinfoResp.StatusCode != http.StatusOK {
-			// Keep the raw response body out of the browser-facing message
-			// (the localhost callback page renders as HTML by default and
-			// could otherwise execute injected markup from a hostile or
-			// misconfigured /userinfo response). The body is still
-			// captured in the returned Go error and the local log so the
-			// caller has the detail needed to diagnose the failure.
-			detail := fmt.Sprintf("/userinfo returned HTTP %d: %q", userinfoResp.StatusCode, userinfoBody)
-			accessTokenErr = errors.New(detail)
-			fmt.Printf("error: %s\n", detail)
-			w.WriteHeader(http.StatusInternalServerError)
-			fmt.Fprintf(w, "error: /userinfo returned HTTP %d", userinfoResp.StatusCode)
+			fail(fmt.Sprintf("/userinfo returned HTTP %d", userinfoResp.StatusCode), safeDetail(string(userinfoBody)))
 			return
 		}
 
 		var userinfoData map[string]interface{}
 		if err := json.Unmarshal(userinfoBody, &userinfoData); err != nil {
-			errHandler("could not unmarshal body from /userinfo: " + err.Error())
+			fail("could not parse /userinfo response", safeDetail(string(userinfoBody)))
 			return
 		}
 
@@ -286,7 +314,7 @@ func InitiateBrowserBasedLogin(notehubApiHost string) (*AccessToken, error) {
 		if email == "" {
 			sub, _ := userinfoData["sub"].(string)
 			if sub == "" {
-				errHandler("/userinfo response missing both email and sub")
+				fail("/userinfo response missing both email and sub", "")
 				return
 			}
 			email = sub

--- a/notehub/auth.go
+++ b/notehub/auth.go
@@ -181,11 +181,13 @@ func InitiateBrowserBasedLogin(notehubApiHost string) (*AccessToken, error) {
 
 		// fail records an authentication failure exactly one way for every
 		// error path in this handler. The browser callback only ever receives
-		// `summary` -- a constant, developer-authored string, never server-
-		// controlled data -- and always as text/plain, so the callback cannot
-		// be used to reflect injected markup or scripts. `detail` (already
-		// passed through safeDetail by the caller) carries diagnostics to the
-		// local log and the returned Go error only.
+		// `summary`, which is composed solely of developer-authored text and
+		// non-injectable scalars such as the numeric HTTP status code -- never
+		// free-form server-controlled bytes -- and is always written as
+		// text/plain, so the callback cannot be used to reflect injected
+		// markup or scripts. `detail` (already passed through safeDetail by
+		// the caller) carries diagnostics to the local log and the returned
+		// Go error only.
 		fail := func(summary, detail string) {
 			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 			w.WriteHeader(http.StatusInternalServerError)
@@ -246,7 +248,7 @@ func InitiateBrowserBasedLogin(notehubApiHost string) (*AccessToken, error) {
 
 		var tokenData map[string]interface{}
 		if err := json.Unmarshal(body, &tokenData); err != nil {
-			fail("could not parse /oauth2/token response", safeDetail(string(body)))
+			fail("could not parse /oauth2/token response", safeDetail(err.Error()+": "+string(body)))
 			return
 		}
 
@@ -306,7 +308,7 @@ func InitiateBrowserBasedLogin(notehubApiHost string) (*AccessToken, error) {
 
 		var userinfoData map[string]interface{}
 		if err := json.Unmarshal(userinfoBody, &userinfoData); err != nil {
-			fail("could not parse /userinfo response", safeDetail(string(userinfoBody)))
+			fail("could not parse /userinfo response", safeDetail(err.Error()+": "+string(userinfoBody)))
 			return
 		}
 

--- a/notehub/auth.go
+++ b/notehub/auth.go
@@ -1,6 +1,7 @@
 package notehub
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/base64"
@@ -34,9 +35,20 @@ const (
 	maxDetailBytes = 1024
 )
 
-// readResponseBody reads up to maxResponseBytes from an HTTP response body.
+// readResponseBody reads an HTTP response body, capping it at maxResponseBytes
+// so a hostile or misconfigured endpoint cannot exhaust memory. Reading one
+// byte past the cap lets it distinguish "too large" from "exactly the limit"
+// and report an explicit error rather than silently truncating (which would
+// later surface as a misleading parse failure).
 func readResponseBody(resp *http.Response) ([]byte, error) {
-	return io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(body) > maxResponseBytes {
+		return nil, fmt.Errorf("response exceeds %d-byte limit", maxResponseBytes)
+	}
+	return body, nil
 }
 
 // safeDetail renders an untrusted value for inclusion in logs and returned
@@ -64,6 +76,15 @@ var sensitiveResponseFields = []string{"access_token", "refresh_token", "id_toke
 func redactSensitive(body []byte) string {
 	var obj map[string]interface{}
 	if err := json.Unmarshal(body, &obj); err != nil {
+		// The body did not parse, so it cannot be redacted field-by-field. If
+		// it nonetheless mentions a credential-bearing field (e.g. a truncated
+		// token response), suppress it entirely rather than risk leaking a
+		// secret; otherwise return it unchanged.
+		for _, field := range sensitiveResponseFields {
+			if bytes.Contains(body, []byte(field)) {
+				return "[unparseable response suppressed: may contain credentials]"
+			}
+		}
 		return string(body)
 	}
 	redacted := false

--- a/notehub/auth.go
+++ b/notehub/auth.go
@@ -51,6 +51,36 @@ func safeDetail(s string) string {
 	return strconv.Quote(s) + suffix
 }
 
+// sensitiveResponseFields are response fields that may carry credentials and
+// must never be written to logs or returned errors.
+var sensitiveResponseFields = []string{"access_token", "refresh_token", "id_token"}
+
+// redactSensitive returns a representation of an HTTP response body that is
+// safe to log: when the body is a JSON object, values of known credential-
+// bearing fields are replaced with a placeholder; otherwise the body is
+// returned unchanged (token endpoints return credentials as JSON, so a
+// non-JSON body has no field to target).
+func redactSensitive(body []byte) string {
+	var obj map[string]interface{}
+	if err := json.Unmarshal(body, &obj); err != nil {
+		return string(body)
+	}
+	redacted := false
+	for _, field := range sensitiveResponseFields {
+		if _, ok := obj[field]; ok {
+			obj[field] = "[REDACTED]"
+			redacted = true
+		}
+	}
+	if !redacted {
+		return string(body)
+	}
+	if out, err := json.Marshal(obj); err == nil {
+		return string(out)
+	}
+	return string(body)
+}
+
 type AccessToken struct {
 	Host        string
 	Email       string
@@ -199,6 +229,15 @@ func InitiateBrowserBasedLogin(notehubApiHost string) (*AccessToken, error) {
 			}
 			fmt.Printf("error: %s\n", msg)
 			accessTokenErr = errors.New(msg)
+
+			// Signal the server to shut down so InitiateBrowserBasedLogin does
+			// not block on <-done waiting for a success that will never come.
+			// Non-blocking: the buffered channel may already hold a signal
+			// (e.g. an OS interrupt or a prior callback).
+			select {
+			case quit <- os.Interrupt:
+			default:
+			}
 		}
 
 		if callbackState != state {
@@ -242,13 +281,13 @@ func InitiateBrowserBasedLogin(notehubApiHost string) (*AccessToken, error) {
 		// unsuccessful response, regardless of whether its body happens to
 		// parse as JSON.
 		if tokenResp.StatusCode != http.StatusOK {
-			fail(fmt.Sprintf("/oauth2/token returned HTTP %d", tokenResp.StatusCode), safeDetail(string(body)))
+			fail(fmt.Sprintf("/oauth2/token returned HTTP %d", tokenResp.StatusCode), safeDetail(redactSensitive(body)))
 			return
 		}
 
 		var tokenData map[string]interface{}
 		if err := json.Unmarshal(body, &tokenData); err != nil {
-			fail("could not parse /oauth2/token response", safeDetail(err.Error()+": "+string(body)))
+			fail("could not parse /oauth2/token response", safeDetail(err.Error()+": "+redactSensitive(body)))
 			return
 		}
 
@@ -302,13 +341,13 @@ func InitiateBrowserBasedLogin(notehubApiHost string) (*AccessToken, error) {
 		}
 
 		if userinfoResp.StatusCode != http.StatusOK {
-			fail(fmt.Sprintf("/userinfo returned HTTP %d", userinfoResp.StatusCode), safeDetail(string(userinfoBody)))
+			fail(fmt.Sprintf("/userinfo returned HTTP %d", userinfoResp.StatusCode), safeDetail(redactSensitive(userinfoBody)))
 			return
 		}
 
 		var userinfoData map[string]interface{}
 		if err := json.Unmarshal(userinfoBody, &userinfoData); err != nil {
-			fail("could not parse /userinfo response", safeDetail(err.Error()+": "+string(userinfoBody)))
+			fail("could not parse /userinfo response", safeDetail(err.Error()+": "+redactSensitive(userinfoBody)))
 			return
 		}
 

--- a/notehub/auth.go
+++ b/notehub/auth.go
@@ -248,7 +248,17 @@ func InitiateBrowserBasedLogin(notehubApiHost string) (*AccessToken, error) {
 		}
 
 		if userinfoResp.StatusCode != http.StatusOK {
-			errHandler(fmt.Sprintf("/userinfo returned HTTP %d: %s", userinfoResp.StatusCode, string(userinfoBody)))
+			// Keep the raw response body out of the browser-facing message
+			// (the localhost callback page renders as HTML by default and
+			// could otherwise execute injected markup from a hostile or
+			// misconfigured /userinfo response). The body is still
+			// captured in the returned Go error and the local log so the
+			// caller has the detail needed to diagnose the failure.
+			detail := fmt.Sprintf("/userinfo returned HTTP %d: %s", userinfoResp.StatusCode, string(userinfoBody))
+			accessTokenErr = errors.New(detail)
+			fmt.Printf("error: %s\n", detail)
+			w.WriteHeader(http.StatusInternalServerError)
+			fmt.Fprintf(w, "error: /userinfo returned HTTP %d", userinfoResp.StatusCode)
 			return
 		}
 

--- a/notehub/auth.go
+++ b/notehub/auth.go
@@ -253,10 +253,15 @@ func InitiateBrowserBasedLogin(notehubApiHost string) (*AccessToken, error) {
 			return
 		}
 
-		email, ok := userinfoData["email"].(string)
-		if !ok {
-			errHandler("could not retrieve email")
-			return
+		// /userinfo may omit "email" depending on IdP configuration; fall
+		// back to the subject ID so we still have a stable user identifier.
+		email, _ := userinfoData["email"].(string)
+		if email == "" {
+			if sub, _ := userinfoData["sub"].(string); sub != "" {
+				email = sub
+			} else {
+				email = "(oauth)"
+			}
 		}
 
 		///////////////////////////////////////////

--- a/notehub/auth.go
+++ b/notehub/auth.go
@@ -150,6 +150,10 @@ func InitiateBrowserBasedLogin(notehubApiHost string) (*AccessToken, error) {
 		callbackState := r.URL.Query().Get("state")
 
 		errHandler := func(msg string) {
+			// text/plain so any server-controlled bytes that reach this
+			// callback (OAuth error_description, JSON unmarshal errors,
+			// etc.) cannot be rendered as HTML by the browser.
+			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 			w.WriteHeader(http.StatusInternalServerError)
 			fmt.Fprintf(w, "error: %s", msg)
 			fmt.Printf("error: %s\n", msg)
@@ -194,7 +198,14 @@ func InitiateBrowserBasedLogin(notehubApiHost string) (*AccessToken, error) {
 
 		var tokenData map[string]interface{}
 		if err := json.Unmarshal(body, &tokenData); err != nil {
-			errHandler("could not unmarshal body from /oauth2/token: " + err.Error())
+			// Surface the HTTP status when /oauth2/token returns a non-200
+			// with a non-JSON body, so the underlying failure isn't hidden
+			// behind a generic unmarshal error.
+			if tokenResp.StatusCode != http.StatusOK {
+				errHandler(fmt.Sprintf("/oauth2/token returned HTTP %d: %q", tokenResp.StatusCode, body))
+			} else {
+				errHandler("could not unmarshal body from /oauth2/token: " + err.Error())
+			}
 			return
 		}
 

--- a/notehub/auth.go
+++ b/notehub/auth.go
@@ -235,15 +235,18 @@ func InitiateBrowserBasedLogin(notehubApiHost string) (*AccessToken, error) {
 			return
 		}
 
+		// Treat any non-200 as a hard failure before consuming any fields, so
+		// we never accept an access token from -- or hide the status of -- an
+		// unsuccessful response, regardless of whether its body happens to
+		// parse as JSON.
+		if tokenResp.StatusCode != http.StatusOK {
+			fail(fmt.Sprintf("/oauth2/token returned HTTP %d", tokenResp.StatusCode), safeDetail(string(body)))
+			return
+		}
+
 		var tokenData map[string]interface{}
 		if err := json.Unmarshal(body, &tokenData); err != nil {
-			// A non-200 with a non-JSON body would otherwise be hidden behind
-			// a generic unmarshal error, so surface the HTTP status too.
-			if tokenResp.StatusCode != http.StatusOK {
-				fail(fmt.Sprintf("/oauth2/token returned HTTP %d", tokenResp.StatusCode), safeDetail(string(body)))
-			} else {
-				fail("could not parse /oauth2/token response", safeDetail(string(body)))
-			}
+			fail("could not parse /oauth2/token response", safeDetail(string(body)))
 			return
 		}
 

--- a/notehub/auth.go
+++ b/notehub/auth.go
@@ -111,23 +111,35 @@ const (
 	// callbackIgnore: not the OAuth redirect (e.g. favicon, prefetch, a bare
 	// visit to the root). Must be answered benignly without affecting the flow.
 	callbackIgnore callbackAction = iota
-	// callbackStateMismatch: carries an authorization code but the wrong state
-	// (a CSRF attempt or a stale redirect). Must fail closed.
+	// callbackStateMismatch: a redirect whose state doesn't match the value the
+	// flow generated (a CSRF attempt or a stale redirect). Must fail closed.
 	callbackStateMismatch
-	// callbackProceed: a well-formed redirect whose state matches.
+	// callbackError: the provider reported an authorization failure (e.g. the
+	// user denied consent), redirecting with an "error" parameter and no code.
+	callbackError
+	// callbackProceed: a well-formed redirect carrying a code whose state
+	// matches.
 	callbackProceed
 )
 
 // classifyCallback decides how to treat a request to the callback server. A
-// request without an authorization code is not the OAuth redirect at all and
-// is ignored; one with a code is honored only if its state matches the value
-// the flow generated.
+// request carrying neither an authorization code nor an OAuth error is not the
+// redirect at all and is ignored. Anything that is the redirect is honored only
+// if its state matches the value the flow generated; an "error" parameter (with
+// no code) signals that authorization was refused or failed.
 func classifyCallback(r *http.Request, expectedState string) callbackAction {
-	if r.URL.Query().Get("code") == "" {
+	q := r.URL.Query()
+	code := q.Get("code")
+	oauthErr := q.Get("error")
+
+	if code == "" && oauthErr == "" {
 		return callbackIgnore
 	}
-	if r.URL.Query().Get("state") != expectedState {
+	if q.Get("state") != expectedState {
 		return callbackStateMismatch
+	}
+	if oauthErr != "" {
+		return callbackError
 	}
 	return callbackProceed
 }
@@ -318,6 +330,19 @@ func InitiateBrowserBasedLogin(notehubApiHost string) (*AccessToken, error) {
 
 		if action == callbackStateMismatch {
 			fail("state mismatch", "")
+			return
+		}
+
+		// The provider refused or failed the authorization (e.g. the user
+		// denied consent). Report it instead of waiting for a code that will
+		// never arrive.
+		if action == callbackError {
+			oauthErr := r.URL.Query().Get("error")
+			detail := oauthErr
+			if desc := r.URL.Query().Get("error_description"); desc != "" {
+				detail = oauthErr + ": " + desc
+			}
+			fail("authorization was not granted", safeDetail(detail))
 			return
 		}
 

--- a/notehub/auth.go
+++ b/notehub/auth.go
@@ -247,6 +247,11 @@ func InitiateBrowserBasedLogin(notehubApiHost string) (*AccessToken, error) {
 			return
 		}
 
+		if userinfoResp.StatusCode != http.StatusOK {
+			errHandler(fmt.Sprintf("/userinfo returned HTTP %d: %s", userinfoResp.StatusCode, string(userinfoBody)))
+			return
+		}
+
 		var userinfoData map[string]interface{}
 		if err := json.Unmarshal(userinfoBody, &userinfoData); err != nil {
 			errHandler("could not unmarshal body from /userinfo: " + err.Error())
@@ -254,14 +259,16 @@ func InitiateBrowserBasedLogin(notehubApiHost string) (*AccessToken, error) {
 		}
 
 		// /userinfo may omit "email" depending on IdP configuration; fall
-		// back to the subject ID so we still have a stable user identifier.
+		// back to the subject identifier, which OIDC requires the userinfo
+		// response to include.
 		email, _ := userinfoData["email"].(string)
 		if email == "" {
-			if sub, _ := userinfoData["sub"].(string); sub != "" {
-				email = sub
-			} else {
-				email = "(oauth)"
+			sub, _ := userinfoData["sub"].(string)
+			if sub == "" {
+				errHandler("/userinfo response missing both email and sub")
+				return
 			}
+			email = sub
 		}
 
 		///////////////////////////////////////////

--- a/notehub/auth.go
+++ b/notehub/auth.go
@@ -254,7 +254,7 @@ func InitiateBrowserBasedLogin(notehubApiHost string) (*AccessToken, error) {
 			// misconfigured /userinfo response). The body is still
 			// captured in the returned Go error and the local log so the
 			// caller has the detail needed to diagnose the failure.
-			detail := fmt.Sprintf("/userinfo returned HTTP %d: %s", userinfoResp.StatusCode, string(userinfoBody))
+			detail := fmt.Sprintf("/userinfo returned HTTP %d: %q", userinfoResp.StatusCode, userinfoBody)
 			accessTokenErr = errors.New(detail)
 			fmt.Printf("error: %s\n", detail)
 			w.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
InitiateBrowserBasedLogin previously treated a missing "email" field in the /userinfo response as fatal, aborting the entire OAuth flow even though the token exchange had already succeeded. In practice Notehub's /userinfo can return HTTP 200 containing only the OIDC bookkeeping claims (sub, iss, aud, iat, ...), which made every browser-based sign-in fail with "could not retrieve email" -- and because the handler does not check the HTTP status code, the actual response was hidden from the user.

Fall back to the subject identifier when email is absent so the caller still receives a populated AccessToken. The Email field is used only as a display/persistence identifier, so the fallback is sufficient for downstream consumers.